### PR TITLE
Use the current branch in testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Gradle
+build/
+.gradle/
+
+# Jenkins
+target/
+
+# Vim
+*.swp
+Session.vim
+

--- a/src/test/groovy/testSupport/PipelineTestBase.groovy
+++ b/src/test/groovy/testSupport/PipelineTestBase.groovy
@@ -22,10 +22,15 @@ class PipelineTestBase extends Specification {
     def setup() {
 
         def lib = new LibraryConfiguration("rsg", new SCMSourceRetriever(new GitSCMSource(null, System.getProperty("user.dir"), "", "*", "0", true)))
-        def proc = Runtime.getRuntime().exec("git branch -m test-branch");
-        proc.waitFor();
+        List<String> gitHeadNameCmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
+        def pb = new ProcessBuilder(gitHeadNameCmd).start()
+        pb.consumeProcessErrorStream(System.err)
+        pb.waitFor();
+        if (pb.exitValue() != 0) {
+            throw new RuntimeException("Error running "+gitHeadNameCmd.join(" ")+". The test must run from a git repository")
+        }
         lib.setImplicit(true)
-        lib.setDefaultVersion('test-branch')
+        lib.setDefaultVersion(pb.text.trim())
         GlobalLibraries.get().setLibraries(Collections.singletonList(lib));
     }
 }


### PR DESCRIPTION
Instead of renaming master to test-branch, use the current branch name.

I am not too sure about line 27 (consuming the error stream), but it seems to work ok.