### PR TITLE
Refactor how tests interact with library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 *.swp
 Session.vim
 
+.copy-of-repo/

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,18 @@ repositories {
     }
 }
 
+task setupRepoCopy(type:Exec) {
+    def stdout = new ByteArrayOutputStream()
+
+    commandLine "./script/test.sh", "setupCopyOfRepo"
+    standardOutput = stdout;
+    doLast {
+        println "Output:\n$stdout";
+    }
+}
+
+tasks.test.dependsOn(setupRepoCopy)
+
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.11'
 

--- a/generate-gradle-build.groovy
+++ b/generate-gradle-build.groovy
@@ -16,6 +16,18 @@ repositories {
     }
 }
 
+task setupRepoCopy(type:Exec) {
+    def stdout = new ByteArrayOutputStream()
+
+    commandLine "./script/test.sh", "setupCopyOfRepo"
+    standardOutput = stdout;
+    doLast {
+        println "Output:\n$stdout";
+    }
+}
+
+tasks.test.dependsOn(setupRepoCopy)
+
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.11'
 

--- a/script/test.sh
+++ b/script/test.sh
@@ -25,6 +25,26 @@ unitTests() {
     echo "TODO: this."
 }
 
+setupCopyOfRepo() {
+    DIRECTORY=".copy-of-repo"
+    oldPWD=$(pwd)
+    
+    if [ -d "$DIRECTORY" ]; then
+        echo "Deleting old copy of repo"
+        rm -rf $DIRECTORY
+    fi
+
+    mkdir $DIRECTORY
+    cd $DIRECTORY
+
+    git init
+    cp -R $oldPWD/* .
+    git add .
+    git commit -m "Initial commit for copy of library repo"
+
+    cd "$oldPWD"
+}
+
 # Default to running the integrationTests.
 if [ -z "$1" ]; then
     integrationTests

--- a/script/test.sh
+++ b/script/test.sh
@@ -35,10 +35,12 @@ setupCopyOfRepo() {
     fi
 
     mkdir $DIRECTORY
+    rsync -a --exclude 'test' src/ $DIRECTORY/src
+    rsync -a vars/ $DIRECTORY/vars
+    rsync -a resources/ $DIRECTORY/resources
     cd $DIRECTORY
-
     git init
-    cp -R $oldPWD/* .
+    
     git add .
     git commit -m "Initial commit for copy of library repo"
 

--- a/src/test/groovy/testSupport/PipelineTestBase.groovy
+++ b/src/test/groovy/testSupport/PipelineTestBase.groovy
@@ -21,16 +21,9 @@ class PipelineTestBase extends Specification {
      */
     def setup() {
 
-        def lib = new LibraryConfiguration("rsg", new SCMSourceRetriever(new GitSCMSource(null, System.getProperty("user.dir"), "", "*", "0", true)))
-        List<String> gitHeadNameCmd = ['git', 'rev-parse', '--abbrev-ref', 'HEAD']
-        def pb = new ProcessBuilder(gitHeadNameCmd).start()
-        pb.consumeProcessErrorStream(System.err)
-        pb.waitFor();
-        if (pb.exitValue() != 0) {
-            throw new RuntimeException("Error running "+gitHeadNameCmd.join(" ")+". The test must run from a git repository")
-        }
+        def lib = new LibraryConfiguration("rsg", new SCMSourceRetriever(new GitSCMSource(null, System.getProperty("user.dir") + "/.copy-of-repo", "", "*", "0", true)))
         lib.setImplicit(true)
-        lib.setDefaultVersion(pb.text.trim())
+        lib.setDefaultVersion("master")
         GlobalLibraries.get().setLibraries(Collections.singletonList(lib));
     }
 }


### PR DESCRIPTION
Now we make a new copy of the library for each test run.

@martinda - What are your thoughts on this? I mentioned the issue I'm trying to solve in #2. Essentially, if you ran the tests before committing in the old method, your tests would use an out of copy, since it was just cloning what git knew of. Also, fiddling around with making sure that we don't screw up our own working copy of the repo was annoying, so instead we'll just make a new local git repository that just contains all the non-hidden files from this repository.